### PR TITLE
Add MXFP8 scenario option for benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ python train_fp8.py \
 
 > **Tip:** Transformer Engine support (`--use_te`) is available for the Meta Llama models. For Qwen2.5 we rely on the standard Hugging Face implementation, so leave `--use_te` unset.
 
+### MXFP8 scenario (Transformer Engine only)
+
+For benchmarks that compare Transformer Engine's MXFP8 recipe against the default FP8 configuration, add the `--fp8_scenario mxfp8` flag alongside `--mixed_precision fp8` and `--use_te`:
+
+```bash
+python train_fp8.py \
+  --model_name meta-llama/Llama-3.2-3B \
+  --dataset_name nvidia/OpenMathInstruct-2 \
+  --batch_size 12 \
+  --mixed_precision fp8 \
+  --fp8_scenario mxfp8 \
+  --max_seq_length 1024 \
+  --num_of_samples 100000 \
+  --use_te \
+  --use_wandb \
+  --wandb_project llm-fp8 \
+  --wandb_run_name llama32-3b-mxfp8
+```
+
+The MXFP8 option falls back to the standard FP8 recipe if the installed `transformer_engine` package does not expose an MXFP8 format.
+
 ## BF16 baseline (optional)
 
 Switch the precision flag to generate a BF16 benchmark run with W&B logging:

--- a/utils.py
+++ b/utils.py
@@ -57,6 +57,9 @@ class HyperParameters:
 
         self.number_samples = None  # Set to None to use the full dataset
 
+        # FP8 configuration
+        self.fp8_scenario = "default"
+
 
 hyperparams = HyperParameters()
 
@@ -169,10 +172,50 @@ def init_model(hp: HyperParameters, use_te: bool = False):
     return model
 
 
+def _build_fp8_handler(hp: HyperParameters):
+    if hp.mixed_precision != "fp8":
+        return None
+
+    scenario = getattr(hp, "fp8_scenario", "default")
+    if scenario == "default":
+        return [FP8RecipeKwargs(backend="te")]
+    if scenario == "mxfp8":
+        try:
+            from transformer_engine.common.recipe import DelayedScaling, Format
+        except ImportError as exc:
+            raise RuntimeError(
+                "The MXFP8 scenario requires transformer_engine to be installed."
+            ) from exc
+
+        members = getattr(Format, "__members__", {})
+        mxfp8_options = [
+            member
+            for name, member in members.items()
+            if "MXFP8" in name.upper()
+        ]
+        if not mxfp8_options:
+            import warnings
+
+            warnings.warn(
+                "MXFP8 scenario requested but no MXFP8 format is available in the "
+                "installed transformer_engine package. Falling back to the default "
+                "FP8 recipe.",
+                stacklevel=2,
+            )
+            return [FP8RecipeKwargs(backend="te")]
+
+        recipe = DelayedScaling(
+            fp8_format=mxfp8_options[0],
+            amax_history_len=16,
+            amax_compute_algo="max",
+        )
+        return [FP8RecipeKwargs(recipe=recipe, backend="te")]
+
+    raise ValueError(f"Unsupported FP8 scenario: {scenario}")
+
+
 def wrap_with_accelerator(model, hp: HyperParameters):
-    fp8_handler = (
-        [FP8RecipeKwargs(backend="te")] if hp.mixed_precision == "fp8" else None
-    )
+    fp8_handler = _build_fp8_handler(hp)
     accelerator = Accelerator(
         gradient_accumulation_steps=hp.gradient_accumulation_steps,
         mixed_precision=hp.mixed_precision,


### PR DESCRIPTION
## Summary
- add an MXFP8 scenario flag to the training benchmark script and utilities so Transformer Engine users can select the new recipe
- gracefully fall back to the default FP8 recipe when the installed Transformer Engine build lacks MXFP8 support
- document the new MXFP8 option in the README with an example command

## Testing
- python -m compileall train_fp8.py utils.py

------
https://chatgpt.com/codex/tasks/task_e_68cff1cb270c83259fb41c7a3a378abc